### PR TITLE
Sync up the toctree entries to have maxdepth:2 and .rst extensions

### DIFF
--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -4,7 +4,7 @@ Advanced Topics
 .. toctree::
    :maxdepth: 2
 
-   confluent/index
-   docker/index
-   hamn/index
-   mixed_cluster
+   confluent/index.rst
+   docker/index.rst
+   hamn/index.rst
+   mixed_cluster.rst

--- a/docs/source/developers/git/index.rst
+++ b/docs/source/developers/git/index.rst
@@ -9,6 +9,6 @@ xCAT uses git for source code version control.  There are many resources and doc
 
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
 

--- a/docs/source/developers/mini-design/index.rst
+++ b/docs/source/developers/mini-design/index.rst
@@ -11,7 +11,7 @@ The **Design Document** for certain feature.
 ----
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    2.11/docker.rst
    2.11/docker-swarm.rst
@@ -19,6 +19,6 @@ The **Design Document** for certain feature.
 2.10
 ----
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    2.10/xcatdebugmode.rst

--- a/docs/source/guides/admin-guides/index.rst
+++ b/docs/source/guides/admin-guides/index.rst
@@ -2,7 +2,7 @@ Admin Guide
 ===========
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    large_clusters/index.rst
    ubuntu_clusters/index.rst

--- a/docs/source/guides/admin-guides/ubuntu_clusters/index.rst
+++ b/docs/source/guides/admin-guides/ubuntu_clusters/index.rst
@@ -4,7 +4,6 @@ Managing Ubuntu/Debian Clusters
 .. toctree::
    :maxdepth: 2
 
-
-   xCAT_on_Ubuntu_Server
-   ../../install-guides/common/prepare_mgmt_node
+   xCAT_on_Ubuntu_Server.rst
+   ../../install-guides/common/prepare_mgmt_node.rst
 

--- a/docs/source/guides/install-guides/apt/index.rst
+++ b/docs/source/guides/install-guides/apt/index.rst
@@ -6,4 +6,4 @@ For the list of currently supported Ubuntu LTS operatin systems, see :ref:`ubunt
 .. toctree::
    :maxdepth: 2
 
-   ../common/prepare_mgmt_node
+   ../common/prepare_mgmt_node.rst

--- a/docs/source/guides/install-guides/index.rst
+++ b/docs/source/guides/install-guides/index.rst
@@ -2,8 +2,8 @@ Install Guides
 ==============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   yum/index
-   zypper/index
-   apt/index 
+   yum/index.rst
+   zypper/index.rst
+   apt/index.rst

--- a/docs/source/guides/install-guides/yum/index.rst
+++ b/docs/source/guides/install-guides/yum/index.rst
@@ -6,6 +6,6 @@ For the list of currently supported RHEL operating systems, see :ref:`rhels-os-s
 .. toctree::
    :maxdepth: 2
 
-   prepare_mgmt_node
-   install_xcat
-   configure_xcat
+   prepare_mgmt_node.rst
+   install_xcat.rst
+   configure_xcat.rst

--- a/docs/source/guides/install-guides/zypper/index.rst
+++ b/docs/source/guides/install-guides/zypper/index.rst
@@ -6,6 +6,6 @@ For the list of currently supported SLES operating systems, see :ref:`sles-os-su
 .. toctree::
    :maxdepth: 2
 
-   prepare_mgmt_node
-..   install_xcat
-..   configure_xcat
+   prepare_mgmt_node.rst
+..   install_xcat.rst
+..   configure_xcat.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,11 +20,11 @@ Content
 .. toctree::
    :maxdepth: 2
 
-   guides/install-guides/index 
-   guides/admin-guides/index 
-   developers/index
-   advanced/index
-   help
+   guides/install-guides/index.rst
+   guides/admin-guides/index.rst
+   developers/index.rst
+   advanced/index.rst
+   help.rst
 
 
 Indices and tables


### PR DESCRIPTION
To keep up with good practices, sync up all the files to explicitly use .rst extension so there's no ambiguity.  Keep the maxdepth to 2 for now as we get more familiar with Sphinx and RTD